### PR TITLE
Fix for "Array to string conversion" when building node index

### DIFF
--- a/Classes/Domain/Service/SqLiteIndex.php
+++ b/Classes/Domain/Service/SqLiteIndex.php
@@ -120,7 +120,6 @@ class SqLiteIndex implements IndexInterface {
 					}
 				}
 				$propertyValue = implode(',', $propertyValue);
-
 			}
 			$preparedStatement->bindValue($this->preparedStatementArgumentName($statementArgumentNumber), $propertyValue);
 			$statementArgumentNumber++;

--- a/Classes/Domain/Service/SqLiteIndex.php
+++ b/Classes/Domain/Service/SqLiteIndex.php
@@ -114,7 +114,13 @@ class SqLiteIndex implements IndexInterface {
 		$statementArgumentNumber = 1;
 		foreach ($properties as $propertyValue) {
 			if (is_array($propertyValue)) {
+				foreach($propertyValue AS $key => $value) {
+					if(is_array($value)) { 
+						$propertyValue[ $key ] = implode(",", $value); 
+					}
+				}
 				$propertyValue = implode(',', $propertyValue);
+
 			}
 			$preparedStatement->bindValue($this->preparedStatementArgumentName($statementArgumentNumber), $propertyValue);
 			$statementArgumentNumber++;


### PR DESCRIPTION
This commit fixes a bug where a nodes property value is an array that contains an array.
If this is the case, PHPs implode function throws a "Array to string conversion" error.

To Reproduce the issue:
* install Neos (v3.3.9) with Neos.Demo package
* install SimpleSearch (composer require flowpack/searchplugin flowpack/simplesearch-contentrepositoryadaptor)
* run ./flow nodeindex.build