### PR TITLE
BUGFIX: Querybuilders didn’t match original interface

### DIFF
--- a/Classes/Search/MysqlQueryBuilder.php
+++ b/Classes/Search/MysqlQueryBuilder.php
@@ -116,10 +116,10 @@ class MysqlQueryBuilder implements QueryBuilderInterface
      * add an exact-match query for a given property
      *
      * @param string $propertyName
-     * @param string $propertyValue
+     * @param mixed $propertyValue
      * @return QueryBuilderInterface
      */
-    public function exactMatch(string $propertyName, $propertyValue): QueryBuilderInterface
+    public function exactMatch($propertyName, $propertyValue): QueryBuilderInterface
     {
         $this->compare($propertyName, $propertyValue, '=');
 

--- a/Classes/Search/QueryBuilderInterface.php
+++ b/Classes/Search/QueryBuilderInterface.php
@@ -15,7 +15,7 @@ interface QueryBuilderInterface
      * @param string $propertyName the property name to sort by
      * @return QueryBuilderInterface
      */
-    public function sortDesc(string $propertyName): QueryBuilderInterface;
+    public function sortDesc($propertyName): QueryBuilderInterface;
 
     /**
      * Sort ascending by $propertyName
@@ -23,7 +23,7 @@ interface QueryBuilderInterface
      * @param string $propertyName the property name to sort by
      * @return QueryBuilderInterface
      */
-    public function sortAsc(string $propertyName): QueryBuilderInterface;
+    public function sortAsc($propertyName): QueryBuilderInterface;
 
     /**
      * output only $limit records
@@ -31,7 +31,7 @@ interface QueryBuilderInterface
      * @param integer $limit
      * @return QueryBuilderInterface
      */
-    public function limit(?int $limit): QueryBuilderInterface;
+    public function limit($limit): QueryBuilderInterface;
 
     /**
      * Start returned results $from number results.
@@ -39,7 +39,7 @@ interface QueryBuilderInterface
      * @param integer $from
      * @return QueryBuilderInterface
      */
-    public function from(?int $from): QueryBuilderInterface;
+    public function from($from): QueryBuilderInterface;
 
     /**
      * add an exact-match query for a given property
@@ -48,7 +48,7 @@ interface QueryBuilderInterface
      * @param mixed $propertyValue
      * @return QueryBuilderInterface
      */
-    public function exactMatch(string $propertyName, $propertyValue): QueryBuilderInterface;
+    public function exactMatch($propertyName, $propertyValue): QueryBuilderInterface;
 
     /**
      * add an like query for a given property
@@ -65,7 +65,7 @@ interface QueryBuilderInterface
      * @param string $searchword
      * @return QueryBuilderInterface
      */
-    public function fulltext(string $searchword): QueryBuilderInterface;
+    public function fulltext($searchword): QueryBuilderInterface;
 
     /**
      * Execute the query and return the list of nodes as result

--- a/Classes/Search/SqLiteQueryBuilder.php
+++ b/Classes/Search/SqLiteQueryBuilder.php
@@ -111,7 +111,7 @@ class SqLiteQueryBuilder implements QueryBuilderInterface
      * @param mixed $propertyValue
      * @return QueryBuilderInterface
      */
-    public function exactMatch(string $propertyName, $propertyValue): QueryBuilderInterface
+    public function exactMatch($propertyName, $propertyValue): QueryBuilderInterface
     {
         $this->compare($propertyName, $propertyValue, '=');
 


### PR DESCRIPTION
Without this change exceptions are thrown because of the mismatch with https://github.com/neos/typo3cr-search/blob/master/Classes/Search/QueryBuilderInterface.php