### PR TITLE
BUGFIX: Add dependency on neos/content-repository-search

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "description": "Plain PHP search engine using sqlite3 or MySQL as storage backend.",
     "license": "MIT",
     "require": {
-        "neos/flow": "^5.0 || ^6.0 || dev-master"
+        "neos/flow": "^5.0 || ^6.0 || dev-master",
+        "neos/content-repository-search": "^4.0 || dev-master"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This makes sure the package is used only with a compatible version of
`neos/content-repository-search`.

Replaces #32