### PR TITLE
TASK: Remove (bogus) neos/content-repository "dependency"

### DIFF
--- a/Classes/Search/QueryBuilderInterface.php
+++ b/Classes/Search/QueryBuilderInterface.php
@@ -68,9 +68,9 @@ interface QueryBuilderInterface
     public function fulltext(string $searchword): QueryBuilderInterface;
 
     /**
-     * Execute the query and return the list of nodes as result
+     * Execute the query and return the list as result
      *
-     * @return array<\Neos\ContentRepository\Domain\Model\NodeInterface>
+     * @return array
      */
     public function execute(): array;
 


### PR DESCRIPTION
The return type of QueryBuilderInterface.execute() claimed to return
an array of NodeInterface, but that's not true with this package (only
with the CR adaptor!)